### PR TITLE
ENT-8333: compliance-report-imports: Copy report definitions from masterfiles distribution point

### DIFF
--- a/compliance-report-imports/README.org
+++ b/compliance-report-imports/README.org
@@ -1,5 +1,3 @@
-This module facilitates distribution of compliance reports via cfbs. Please note, it's *experimental*.
+This module is expected to run on CFEngine Enterprise Hubs. It facilitates distribution of compliance reports via cfbs. Please note, it's *experimental*.
 
-It copies files from =.no-distrib/compliance-report-definitions= in the policy to =/var/cfengine/imports/compliance-reports= and imports all files in =/var/cfengine/imports/compliance-reports=.
-
-
+This module copies files from =$(sys.masterdir)/.no-distrib/compliance-report-definitions= to =/var/cfengine/imports/compliance-reports= and imports all files in =/var/cfengine/imports/compliance-reports=.

--- a/compliance-report-imports/compliance-report-imports.cf
+++ b/compliance-report-imports/compliance-report-imports.cf
@@ -27,7 +27,7 @@ bundle agent compliance_report_imports
   files:
       "$(sys.workdir)/imports/compliance-reports/."
         create => "true",
-        copy_from => local_dcp( "$(sys.policy_entry_dirname)/.no-distrib/compliance-report-definitions/"),
+        copy_from => local_dcp( "$(sys.masterdir)/.no-distrib/compliance-report-definitions/"),
         depth_search => recurse( "inf" );
 
       "$(sys.bindir)/compliance-report-definition-importer.sh"


### PR DESCRIPTION
Prior to this change the directory where we expect to import compliance report
definitions from (/var/cfengine/imports/compliance-reports) was populated with
data from the policy inputs. Since these assets live in the .no-distrib
directory they are not distributed to inputs by default and they need to be
explicitly copied down if desired (that's what this change is about).

Ticket: ENT-8333
Changelog: Title