### PR TITLE
CFE-3938: Reduced noise from compliance-report-imports

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -56,7 +56,7 @@
     },
     "compliance-report-imports": {
       "name": "compliance-report-imports",
-      "version": "0.0.3",
+      "version": "0.0.5",
       "tags": ["experimental", "cfengine-enterprise"],
       "dependencies": ["autorun"],
       "subdirectory": "./compliance-report-imports",

--- a/compliance-report-imports/compliance-report-imports.cf
+++ b/compliance-report-imports/compliance-report-imports.cf
@@ -48,8 +48,14 @@ WHERE export_id IS null AND name IN ('OS is reported', 'Supported CentOS', 'Supp
         template_method => "inline_mustache";
 
   commands:
-   "$(sys.bindir)/compliance-report-definition-importer.sh";
+   "$(sys.bindir)/compliance-report-definition-importer.sh"
+     contain => silent,
+     inform => "false",
+     classes => default:results( "bundle", "compliance_reports_import" );
 
+  reports:
+   compliance_reports_import_repaired.(inform_mode|verbose_mode|debug_mode)::
+     "Compliance reports imported successfully";
 }
 bundle agent __main__
 {

--- a/compliance-report-imports/compliance-report-imports.cf
+++ b/compliance-report-imports/compliance-report-imports.cf
@@ -27,12 +27,12 @@ bundle agent compliance_report_imports
   files:
       "$(sys.workdir)/imports/compliance-reports/."
         create => "true",
-        copy_from => local_dcp( "$(sys.masterdir)/.no-distrib/compliance-report-definitions/"),
-        depth_search => recurse( "inf" );
+        copy_from => default:local_dcp( "$(sys.policy_entry_dirname)/.no-distrib/compliance-report-definitions/"),
+        depth_search => default:recurse( "inf" );
 
       "$(sys.bindir)/compliance-report-definition-importer.sh"
         create => "true",
-        perms => mog( "700", "root", "root" ),
+        perms => default:mog( "700", "root", "root" ),
         edit_template_string => `#!/bin/bash
 {{#vars.$(this.bundle)._all_import_files}}
    $(sys.bindir)/psql -d cfmp -c "UPDATE dashboard_rules
@@ -49,7 +49,7 @@ WHERE export_id IS null AND name IN ('OS is reported', 'Supported CentOS', 'Supp
 
   commands:
    "$(sys.bindir)/compliance-report-definition-importer.sh"
-     contain => silent,
+     contain => default:silent,
      inform => "false",
      classes => default:results( "bundle", "compliance_reports_import" );
 


### PR DESCRIPTION
This change suppresses output from the compliance reports import script
execution and adds a report about successful import when info, verbose, or
debug logging is requested.

Ticket: CFE-3938
Changelog: Title

Output running with `-KI` ...

Before:

```
  info: Executing 'no timeout' ... '/var/cfengine/bin/compliance-report-definition-importer.sh'
  notice: Q: "...mporter.sh": UPDATE 0
Q: "...mporter.sh":   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Q: "...mporter.sh":                                  Dload  Upload   Total   Spent    Left  Speed
100  3445  100   330  100  3115    731   6901 --:--:-- --:--:-- --:--:--  6891
Q: "...mporter.sh": {
Q: "...mporter.sh":     "processed-conditions": {
Q: "...mporter.sh":         "os-is-reported": 94,
Q: "...mporter.sh":         "supported-debian": 95,
Q: "...mporter.sh":         "supported-rhel": 96,
Q: "...mporter.sh":         "supported-ubuntu": 97,
Q: "...mporter.sh":         "supported-suse": 98,
Q: "...mporter.sh":         "supported-centos": 99,
Q: "...mporter.sh":         "supported-windows": 100
Q: "...mporter.sh":     },
Q: "...mporter.sh":     "processed-reports": {
Q: "...mporter.sh":         "os-is-vendor-supported": 158
Q: "...mporter.sh":     }
Q: "...mporter.sh": }
    info: Last 18 quoted lines were generated by promiser '/var/cfengine/bin/compliance-report-definition-importer.sh'
    info: Completed execution of '/var/cfengine/bin/compliance-report-definition-importer.sh'
```

After:

```
R: Compliance reports imported successfully
```
