### PR TITLE
ENT_9736: Changed from check that os is reported to also check that the os is not unknown

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -121,7 +121,7 @@
     },
     "compliance-report-os-is-vendor-supported": {
       "name": "compliance-report-os-is-vendor-supported",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "tags": ["experimental", "compliance-report", "cfengine-enterprise"],
       "dependencies": ["compliance-report-imports"],
       "subdirectory": "./compliance-report-os-is-vendor-supported",

--- a/compliance-report-os-is-vendor-supported/os-is-vendor-supported.json
+++ b/compliance-report-os-is-vendor-supported/os-is-vendor-supported.json
@@ -19,10 +19,17 @@
     "os-is-reported": {
       "id": "os-is-reported",
       "name": "OS is reported",
-      "description": "All hosts must report their own OS",
+      "description": "All hosts must report their own OS and not be unknown",
       "type": "inventory",
       "condition_for": "passing",
-      "rules": [{"attribute": "OS", "operator": "is_reported", "value": ""}],
+      "rules": [
+        { "attribute": "OS", "operator": "is_reported", "value": "" },
+        {
+          "attribute": "OS",
+          "operator": "regex_not_match",
+          "value": ".*(?i)unknown.*"
+        }
+      ],
       "category": "Operating System",
       "severity": "high",
       "host_filter": null


### PR DESCRIPTION
Prior to this change, simply having any value reported sufficed. Now the
inventory attribute for OS must be reported but also not contain 'unknown' (case
insensitive).

Ticket: ENT-9736
Changelog: Title