### PR TITLE
ENT-11146: Switched to CFEngine vendored curl for compliance report imports

### DIFF
--- a/cfbs.json
+++ b/cfbs.json
@@ -112,7 +112,6 @@
     },
     "compliance-report-imports": {
       "name": "compliance-report-imports",
-      "version": "0.0.6",
       "tags": ["experimental", "cfengine-enterprise"],
       "dependencies": ["autorun"],
       "subdirectory": "./compliance-report-imports",

--- a/compliance-report-imports/compliance-report-imports.cf
+++ b/compliance-report-imports/compliance-report-imports.cf
@@ -39,7 +39,7 @@ bundle agent compliance_report_imports
          $(sys.bindir)/psql -d cfmp -c "UPDATE dashboard_rules
 SET export_id=LOWER(REPLACE(name, ' ', '-'))
 WHERE export_id IS null AND name IN ('OS is reported', 'Supported CentOS', 'Supported Debian', 'Supported RHEL', 'Supported Ubuntu');"
-         curl -k https://127.0.0.1/advancedreports/complianceReport/import \
+         $(sys.bindir)/curl -k https://127.0.0.1/advancedreports/complianceReport/import \
          --user CFE_ROBOT:$(_stuff[cf_robot_password]) \
          -X POST \
          --form 'data=<{{{.}}}' \


### PR DESCRIPTION
The compliance-report-imports module uses curl to load the report. Prior to this
change curl from PATH was used, but curl is not always available. Since CFEngine
enterprise vendors curl this change switches to using that binary.

Ticket: ENT-11146
Changelog: None

Closes #28 