### PR TITLE
Update os-is-vendor-supported.json

### DIFF
--- a/compliance-report-os-is-vendor-supported/os-is-vendor-supported.json
+++ b/compliance-report-os-is-vendor-supported/os-is-vendor-supported.json
@@ -44,7 +44,7 @@
         {
           "attribute": "OS",
           "operator": "regex_matches",
-          "value": "Debian (10|11)"
+          "value": "Debian (11|12)"
         }
       ],
       "category": "Operating System",
@@ -78,7 +78,7 @@
         {
           "attribute": "OS",
           "operator": "regex_matches",
-          "value": "Ubuntu (18|20|22)"
+          "value": "Ubuntu (20|22)"
         }
       ],
       "category": "Operating System",
@@ -112,7 +112,7 @@
         {
           "attribute": "OS",
           "operator": "regex_matches",
-          "value": "CentOS (8)"
+          "value": "CentOS (8|9)"
         }
       ],
       "category": "Operating System",
@@ -129,7 +129,7 @@
         {
           "attribute": "OS",
           "operator": "regex_matches",
-          "value": "Windows (10|11|2019|2022)"
+          "value": "Windows (10|11|2022)"
         }
       ],
       "category": "Operating System",


### PR DESCRIPTION
Based on
https://endoflife.date/debian
https://endoflife.date/windows
https://endoflife.date/windows-server
https://endoflife.date/ubuntu
https://endoflife.date/sles
https://endoflife.date/rhel
https://endoflife.date/centos-stream
https://endoflife.date/centos

Though I am not 100% sure about CentOS vs CentOS stream inventory of OS attribute so should probably check that.